### PR TITLE
Fixing the module

### DIFF
--- a/src/Backend/Modules/Instagram/Installer/Data/install.sql
+++ b/src/Backend/Modules/Instagram/Installer/Data/install.sql
@@ -1,8 +1,8 @@
-CREATE TABLE `instagram_users` (
+CREATE TABLE IF NOT EXISTS `instagram_users` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-  `username` varchar(30) DEFAULT '',
-  `user_id` int(11) DEFAULT NULL,
-  `extra_id` int(11) DEFAULT NULL,
+  `username` varchar(30) NOT NULL DEFAULT '',
+  `user_id` varchar(50) NOT NULL DEFAULT '',
+  `extra_id` int(11) NOT NULL,
   `locked` enum('N','Y') NOT NULL DEFAULT 'N',
   `hidden` enum('N','Y') NOT NULL DEFAULT 'N',
   `created_on` datetime DEFAULT NULL,

--- a/src/Backend/Modules/Instagram/Installer/Installer.php
+++ b/src/Backend/Modules/Instagram/Installer/Installer.php
@@ -36,8 +36,7 @@ class Installer extends ModuleInstaller
         $this->setSetting('Instagram', 'num_recent_items', 10);
         $this->setSetting('Instagram', 'client_id', null);
         $this->setSetting('Instagram', 'client_secret', null);
-        $this->setSetting('Instagram', 'username', null);
-        $this->setSetting('Instagram', 'user_id', null);
+        $this->setSetting('Instagram', 'default_instagram_user_id', null);
         $this->setSetting('Instagram', 'access_token', null);
 
         // Set navigation


### PR DESCRIPTION
The field 'user_id' must be a varchar instead of an integer.
This caused errors in frontend: http://stackoverflow.com/questions/33939089/instagram-this-user-does-not-exist

But I noticed that when using "self" it worked. Then I investigated and the "user_id" was a string and when saving into "instagram_users" table it converted it to an integer, resulting in a different user_id...
